### PR TITLE
fix a typo in example 3 in lecture 3

### DIFF
--- a/lecture3.tex
+++ b/lecture3.tex
@@ -121,7 +121,7 @@ Med denna definition gjord kan vi nu resonera algebraiskt om mängder och deras 
   Hur många heltalslösningar finns det till $x_1 + x_2 + x_3 = 20$, där $0 \leq x_1 \leq 8$, $0 \leq x_2 \leq 10$, och $0 \leq x_3 \leq 12$?
 
   Låt
-  $$X = \left\{(x_1, x_2, x_2) \in \Z_{\geq 0}^3 \given x_1 + x_2 + x_3 = 20\right\}$$
+  $$X = \left\{(x_1, x_2, x_3) \in \Z_{\geq 0}^3 \given x_1 + x_2 + x_3 = 20\right\}$$
   och låt
   $$A_1 = \left\{(x_1, x_2, x_3) \in \Z_{\geq 0}^3 \given x_1 + x_2 + x_3 = 20, x_1 > 8\right\},$$
   $$A_2 = \left\{(x_1, x_2, x_3) \in \Z_{\geq 0}^3 \given x_1 + x_2 + x_3 = 20, x_2 > 10\right\},$$


### PR DESCRIPTION
This commit corrects a typo in example 3 in lecture3.tex. Namely that
$x_2$ is replaced by $x_3$.  Not sure if this qualifies for a bonus
point on the exam.
